### PR TITLE
Fix major bug & adjust and refactor small snippets

### DIFF
--- a/src/main/java/com/mrivanplays/jdcf/CommandManager.java
+++ b/src/main/java/com/mrivanplays/jdcf/CommandManager.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.events.GenericEvent;
@@ -52,6 +53,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class CommandManager implements EventListener
 {
+
+    private static final Pattern ALIAS_SPLIT_PATTERN = Pattern.compile("\\|");
 
     private final List<RegisteredCommand> commands;
     private CommandSettings commandSettings;
@@ -90,9 +93,8 @@ public final class CommandManager implements EventListener
      * Registers the specified command into the manager.
      *
      * @param command the command you wish to register
-     * @param <T>     a parent class to the command one
      */
-    public <T extends Command> void registerCommand(@NotNull T command)
+    public void registerCommand(@NotNull Command command)
     {
         String[] aliases = null;
         String description = null;
@@ -101,7 +103,7 @@ public final class CommandManager implements EventListener
         CommandAliases annoAliases = commandClass.getAnnotation(CommandAliases.class);
         if (annoAliases != null)
         {
-            aliases = annoAliases.value().split("|");
+            aliases = ALIAS_SPLIT_PATTERN.split(annoAliases.value());
         }
         CommandDescription annoDescription = commandClass.getAnnotation(CommandDescription.class);
         if (annoDescription != null)

--- a/src/main/java/com/mrivanplays/jdcf/settings/prefix/DefaultPrefixHandler.java
+++ b/src/main/java/com/mrivanplays/jdcf/settings/prefix/DefaultPrefixHandler.java
@@ -66,7 +66,7 @@ public class DefaultPrefixHandler implements PrefixHandler
         catch (IOException ignored)
         {
         }
-        executorService.scheduleAtFixedRate(() -> savePrefixes(), 5, 30, TimeUnit.MINUTES);
+        executorService.scheduleAtFixedRate(this::savePrefixes, 5, 30, TimeUnit.MINUTES);
     }
 
     private void createFile()

--- a/src/main/java/com/mrivanplays/jdcf/util/EventWaiter.java
+++ b/src/main/java/com/mrivanplays/jdcf/util/EventWaiter.java
@@ -52,6 +52,7 @@ public class EventWaiter implements EventListener
         }, 5, TimeUnit.MINUTES);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public void onEvent(@Nonnull GenericEvent genericEvent)
     {
@@ -77,11 +78,11 @@ public class EventWaiter implements EventListener
     private static class Waiting<T>
     {
 
-        public Class<T> waitingEvent;
-        public Predicate<T> filter;
-        public Consumer<T> onFilterPassed;
+        final Class<T> waitingEvent;
+        final Predicate<T> filter;
+        final Consumer<T> onFilterPassed;
 
-        public Waiting(Class<T> waitingEvent, Predicate<T> filter, Consumer<T> onFilterPassed)
+        Waiting(Class<T> waitingEvent, Predicate<T> filter, Consumer<T> onFilterPassed)
         {
             this.waitingEvent = waitingEvent;
             this.filter = filter;


### PR DESCRIPTION
This PR includes:

- Adding `@SuppressWarnings("unchecked")` to `EventWaiter#onEvent(GenericEvent)`
- Replacing a lambda expression in `DefaultPrefixHandler` with a method reference
- Removing unnecessary generics in `CommandManager#registerCommand(Command)` (this affects the API)

Also, I fixed a major bug in the way the value of `@CommandAliases` is split.
It used to be like this:

`value.split("|")`

The unescaped regex meta character `|` does not result in the desired split policy:

```java
jshell> "foo|bar|baz".split("|")
$2 ==> String[11] { "f", "o", "o", "|", "b", "a", "r", "|", "b", "a", "z" }
```

To fix this, I added a static `Pattern` constant that is reused for splitting (which reduces overhead) and that escapes the character. 

You should add unit tests to find such issues before publishing releases.
Also, I recommend changing the return type of `CommandAliases#value()` to `String[]`, so that unrecognised problems like this don't occur in the first place. But I leave that change up to you.
